### PR TITLE
Move header menu left and enlarge navigation

### DIFF
--- a/style.css
+++ b/style.css
@@ -46,15 +46,19 @@ body {
     z-index: 100;
 }
 
+
 .nav.container {
     display: flex;
     align-items: center;
-    justify-content: space-between;
-    padding: 0.75rem 1rem;
+    justify-content: flex-start;
+    gap: 1.5rem;
+    padding: 1rem 1.5rem;
+    margin: 0;
+    max-width: 100%;
 }
 
 .logo {
-    font-size: 1.5rem;
+    font-size: 2rem;
     font-weight: bold;
     color: var(--color-accent-blue);
     text-decoration: none;
@@ -63,10 +67,11 @@ body {
 .nav-list {
     list-style: none;
     display: flex;
-    gap: 1rem;
+    gap: 1.5rem;
 }
 
 .nav-list a {
+    font-size: 1.125rem;
     text-decoration: none;
     color: var(--color-text-primary);
     transition: color var(--transition-speed);


### PR DESCRIPTION
## Summary
- Align navigation header to the left and expand it with larger spacing and fonts for a more prominent appearance

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688c6c4a3d04832a8c993c92febde7c2