### PR TITLE
Add Tower game at site bottom

### DIFF
--- a/index.html
+++ b/index.html
@@ -198,9 +198,15 @@
                     <label for="email">Email:</label>
                     <input type="email" id="email" name="email" required>
                     <label for="message">Сообщение:</label>
-                    <textarea id="message" name="message" rows="4" required></textarea>
-                    <button type="submit" class="btn">Отправить</button>
+                <textarea id="message" name="message" rows="4" required></textarea>
+                <button type="submit" class="btn">Отправить</button>
                 </form>
+            </div>
+        </section>
+        <section id="game" class="section game">
+            <div class="container">
+                <h2>Мини-игра</h2>
+                <iframe src="Tower/index.html" title="Tower game" class="game-frame"></iframe>
             </div>
         </section>
     </main>

--- a/style.css
+++ b/style.css
@@ -368,6 +368,20 @@ body {
     color: var(--color-text-primary);
 }
 
+/* Game section */
+.section.game {
+    text-align: center;
+}
+
+.game-frame {
+    width: 100%;
+    max-width: 800px;
+    height: 500px;
+    border: none;
+    border-radius: 8px;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.5);
+}
+
 /* Footer */
 .footer {
     background: var(--color-bg-secondary);
@@ -411,6 +425,10 @@ body {
         max-height: 500px;
         opacity: 1;
         transform: translateY(0);
+    }
+
+    .game-frame {
+        height: 300px;
     }
 }
 


### PR DESCRIPTION
## Summary
- embed Tower mini-game via iframe at bottom of main page
- add styling for game frame with responsive height

## Testing
- `npx --yes hint index.html`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68910074543c832a9f7bc56ca663a017