### PR TITLE
fix: enable tower button

### DIFF
--- a/index.html
+++ b/index.html
@@ -206,7 +206,7 @@
         </section>
         <section id="game" class="section game">
             <div class="container">
-                <button id="tower-toggle" class="btn" aria-expanded="false">Башенка</button>
+                <button id="tower-toggle" class="btn" aria-expanded="false" type="button">Башенка</button>
                 <div id="tower-wrapper" hidden>
                     <iframe src="Tower/index.html" title="Tower game" class="game-frame" loading="lazy" sandbox="allow-same-origin allow-scripts"></iframe>
                 </div>

--- a/script.js
+++ b/script.js
@@ -105,14 +105,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const towerWrapper = document.getElementById('tower-wrapper');
     if (towerToggle && towerWrapper) {
       towerToggle.addEventListener('click', () => {
-        const isHidden = towerWrapper.hasAttribute('hidden');
-        if (isHidden) {
-          towerWrapper.removeAttribute('hidden');
-          towerToggle.setAttribute('aria-expanded', 'true');
-        } else {
-          towerWrapper.setAttribute('hidden', '');
-          towerToggle.setAttribute('aria-expanded', 'false');
-        }
+        towerWrapper.hidden = !towerWrapper.hidden;
+        towerToggle.setAttribute('aria-expanded', String(!towerWrapper.hidden));
       });
     }
   });


### PR DESCRIPTION
## Summary
- prevent tower button from submitting forms and toggle game via `hidden`

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/CrabopuluS.github.io/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68910ad9b0c8832ab779ebc1ca47e9e4